### PR TITLE
Pubsub Subscriber as a ZStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+project/target
+target/
+.bsp/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 project/target
 target/
 .bsp/
+.metals/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,12 @@
+version = "2.6.2"
+maxColumn = 120
+assumeStandardLibraryStripMargin = true
+lineEndings = preserve
+includeCurlyBraceInSelectChains = false
+danglingParentheses.preset = true
+spaces {
+  inImportCurlyBraces = true
+}
+optIn.annotationNewlines = true
+
+rewrite.rules = [SortImports, RedundantBraces]

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,17 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
 
+resolvers +=
+  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+
 lazy val root = (project in file("."))
   .settings(
     name := "pubsub-zstreams",
     libraryDependencies ++= Seq(
       "io.github.kitlangton" %% "zio-magic" % "0.3.8",
-      "dev.zio" %% "zio" % "1.0.11",
-      "dev.zio" %% "zio-test" % "1.0.11" % Test,
+      "dev.zio" %% "zio-streams" % "1.0.11+68-c4fb1856-SNAPSHOT",
+      "dev.zio" %% "zio" % "1.0.11+68-c4fb1856-SNAPSHOT",
+      "dev.zio" %% "zio-test" % "1.0.11+68-c4fb1856-SNAPSHOT" % Test,
       "com.google.cloud" % "google-cloud-pubsub" % "1.104.1"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organizationName := "example"
 
 lazy val root = (project in file("."))
   .settings(
-    name := "pegasus",
+    name := "pubsub-zstreams",
     libraryDependencies ++= Seq(
       "io.github.kitlangton" %% "zio-magic" % "0.3.8",
       "dev.zio" %% "zio" % "1.0.11",

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,16 @@
+ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "com.example"
+ThisBuild / organizationName := "example"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "pegasus",
+    libraryDependencies ++= Seq(
+      "io.github.kitlangton" %% "zio-magic" % "0.3.8",
+      "dev.zio" %% "zio" % "1.0.11",
+      "dev.zio" %% "zio-test" % "1.0.11" % Test,
+      "com.google.cloud" % "google-cloud-pubsub" % "1.104.1"
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,0 +1,69 @@
+import com.google.pubsub.v1.PubsubMessage
+import subscriber.{ DecodingFailure, MessageDecoder, PubSubSubscriber, PubSubSubscriberConfig }
+import zio._
+import zio.blocking.Blocking
+import zio.clock._
+import zio.console._
+import zio.duration._
+
+object MessagesAsString {
+
+  implicit val decoder = (message: PubsubMessage) => message.getData.toString("UTF-8")
+  val stringDecoder: MessageDecoder[String] = MessageDecoder[String]
+
+  val config = PubSubSubscriberConfig()
+
+  val subscriptionStream =
+    PubSubSubscriber.subscribe("hf-data-staging", "my-subscription", config, stringDecoder)
+
+  val program: ZIO[Console with Blocking with Clock, Throwable, Option[Unit]] = subscriptionStream.use { stream =>
+    stream.mapM { value =>
+      for {
+        decoded <- value.value
+        print <- putStrLn(s"decoded: ${decoded}") *> value.ack
+      } yield print
+    }.runDrain
+      .timeout(30.seconds)
+  }
+
+}
+
+object MessagesAsAttributes {
+  implicit val decoder = (message: PubsubMessage) => {
+    val messageAsMap = message.getAttributesMap
+    val att1 = messageAsMap.get("att1").head.toString
+    val att2 = messageAsMap.get("att2")
+    MessageAttributes(att1, att2)
+  }
+  val attributesDecoder: MessageDecoder[MessageAttributes] = MessageDecoder[MessageAttributes]
+
+  val config = PubSubSubscriberConfig()
+  val subscriptionStream =
+    PubSubSubscriber.subscribe("hf-data-staging", "my-subscription", config, attributesDecoder)
+  val program: ZIO[Console with Blocking with Clock, Throwable, Option[Unit]] = subscriptionStream.use { stream =>
+    stream.mapM { value =>
+      val action: ZIO[Console, Throwable, Unit] = for {
+        decoded <- value.value
+        print <- putStrLn(s"decoded: ${decoded}") *> value.ack
+      } yield print
+
+      action.catchSome {
+        case _: DecodingFailure =>
+          putStrLn("decoding failed") *> value.nack
+      }
+    }.runDrain
+      .timeout(30.seconds)
+
+  }
+
+  //this decoder will cause a decoder failure
+  case class MessageAttributes(att1: String, att2: String)
+
+}
+
+object Main extends App {
+
+  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+    MessagesAsString.program.exitCode
+
+}

--- a/src/main/scala/subscriber/MessageDecoder.scala
+++ b/src/main/scala/subscriber/MessageDecoder.scala
@@ -1,0 +1,16 @@
+package subscriber
+
+import com.google.pubsub.v1.PubsubMessage
+import zio.{IO, ZIO}
+
+trait MessageDecoder[A] {
+
+  def decode(message: PubsubMessage): IO[DecodingFailure, A]
+
+}
+
+object MessageDecoder {
+
+  def apply[A](implicit decoder: PubsubMessage => A): MessageDecoder[A] =
+    (message: PubsubMessage) => ZIO.effect(decoder(message)).mapError(DecodingFailure)
+}

--- a/src/main/scala/subscriber/PubSubSubscriber.scala
+++ b/src/main/scala/subscriber/PubSubSubscriber.scala
@@ -6,9 +6,9 @@ import com.google.api.gax.core.InstantiatingExecutorProvider
 import com.google.cloud.pubsub.v1.{ AckReplyConsumer, MessageReceiver, Subscriber => GSubscriber }
 import com.google.pubsub.v1.{ ProjectSubscriptionName, PubsubMessage }
 import org.threeten.bp.Duration
+import zio._
 import zio.blocking._
 import zio.stream.ZStream
-import zio.{ IO, Queue, ZIO, ZManaged }
 
 import java.util.concurrent.TimeUnit
 
@@ -19,94 +19,58 @@ object PubSubSubscriber {
       subscription: String,
       config: PubSubSubscriberConfig,
       decoder: MessageDecoder[A]
-  ): ZManaged[Blocking, PubSubError, ZStream[Any, Throwable, DecodedMessage[A]]] =
-    for {
-      queue <-
-        Queue
-          .bounded[IO[Throwable, RawMessage]](config.maxOutstandingElementCount)
-          .toManaged(_.shutdown)
-
-      runtime <- ZIO.runtime[Any].toManaged_
-      _ <- createSubscriber(
-        projectId,
-        subscription,
-        config,
-        value =>
-          runtime.unsafeRunAsync_(
-            queue.offer(
-              value
+  ): ZStream[Blocking, SubscriptionError, DecodedMessage[A]] =
+    ZStream.effectAsyncManaged[Blocking, SubscriptionError, DecodedMessage[A]] { callback =>
+      val receiver: MessageReceiver =
+        (message: PubsubMessage, consumer: AckReplyConsumer) => {
+          callback(
+            //currently decoding failures will not fail the stream, but this can be modified if needed
+            ZIO.succeed(
+              Chunk(DecodedMessage(decoder.decode(message), IO.effect(consumer.ack), IO.effect(consumer.nack())))
             )
           )
-      )
-    } yield ZStream.repeatEffect(takeNextAndDecode(queue, decoder))
+        }
 
-  private def createSubscriber(
-      projectId: String,
-      subscription: String,
-      config: PubSubSubscriberConfig,
-      callback: IO[PubSubError, RawMessage] => Unit
-  ): ZManaged[Blocking, PubSubError, GSubscriber] = {
-
-    //uses the default executor provider
-    //default number of threads is number of CPUs and opens only one stream parallel pull count (1)
-    val executorProvider = InstantiatingExecutorProvider
-      .newBuilder()
-      .build()
-
-    val flowControlSettings = FlowControlSettings
-      .newBuilder()
-      .setMaxOutstandingElementCount(config.maxOutstandingElementCount)
-      .setMaxOutstandingRequestBytes(config.maxOutstandingRequestBytes)
-      .build()
-
-    val name = ProjectSubscriptionName.of(projectId, subscription)
-    val subscriber =
-      GSubscriber
-        .newBuilder(name, new PubSubMessageReceiver(callback))
-        .setParallelPullCount(1)
-        .setFlowControlSettings(flowControlSettings)
-        .setExecutorProvider(executorProvider)
-        .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
+      //uses the default executor provider
+      //default number of threads is number of CPUs and opens only one stream parallel pull count (1)
+      val executorProvider = InstantiatingExecutorProvider
+        .newBuilder()
         .build()
 
-    subscriber.addListener(
-      new Listener {
-        override def failed(
-            state: State,
-            t: Throwable
-        ): Unit = callback(ZIO.fail(PubSubError(t)))
-      },
-      executorProvider.getExecutor()
-    )
+      val flowControlSettings = FlowControlSettings
+        .newBuilder()
+        .setMaxOutstandingElementCount(config.maxOutstandingElementCount)
+        .setMaxOutstandingRequestBytes(config.maxOutstandingRequestBytes)
+        .build()
 
-    effectBlocking(subscriber.startAsync().awaitRunning())
-      .mapBoth(PubSubError, _ => subscriber)
-      .toManaged(s =>
-        effectBlockingInterrupt(
-          s.stopAsync.awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS)
-        ).ignore
+      val name = ProjectSubscriptionName.of(projectId, subscription)
+      val subscriber =
+        GSubscriber
+          .newBuilder(name, receiver)
+          .setParallelPullCount(1)
+          .setFlowControlSettings(flowControlSettings)
+          .setExecutorProvider(executorProvider)
+          .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
+          .build()
+
+      subscriber.addListener(
+        new Listener {
+          override def failed(
+              state: State,
+              t: Throwable
+          ): Unit = callback(ZIO.fail(Some(PubSubError(t))))
+        },
+        executorProvider.getExecutor()
       )
 
-  }
+      effectBlocking(subscriber.startAsync().awaitRunning())
+        .mapBoth(PubSubError, _ => subscriber)
+        .toManaged(s =>
+          effectBlocking(
+            s.stopAsync.awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS)
+          ).ignore
+        )
 
-  def takeNextAndDecode[A](
-      queue: Queue[IO[Throwable, RawMessage]],
-      decoder: MessageDecoder[A]
-  ): ZIO[Any, Throwable, DecodedMessage[A]] =
-    for {
-      message <- queue.take
-      value: RawMessage <- message
-    } yield DecodedMessage(decoder.decode(value.value), value.ack, value.nack)
-
-  class PubSubMessageReceiver(
-      callback: IO[PubSubError, RawMessage] => Unit
-  ) extends MessageReceiver {
-
-    override def receiveMessage(message: PubsubMessage, consumer: AckReplyConsumer): Unit =
-      callback(
-        ZIO.succeed(RawMessage(message, IO.effect(consumer.ack()), IO.effect(consumer.nack())))
-      )
-
-  }
+    }
 
 }

--- a/src/main/scala/subscriber/PubSubSubscriber.scala
+++ b/src/main/scala/subscriber/PubSubSubscriber.scala
@@ -1,0 +1,112 @@
+package subscriber
+
+import com.google.api.core.ApiService.{ Listener, State }
+import com.google.api.gax.batching.FlowControlSettings
+import com.google.api.gax.core.InstantiatingExecutorProvider
+import com.google.cloud.pubsub.v1.{ AckReplyConsumer, MessageReceiver, Subscriber => GSubscriber }
+import com.google.pubsub.v1.{ ProjectSubscriptionName, PubsubMessage }
+import org.threeten.bp.Duration
+import zio.blocking._
+import zio.stream.ZStream
+import zio.{ IO, Queue, ZIO, ZManaged }
+
+import java.util.concurrent.TimeUnit
+
+object PubSubSubscriber {
+
+  def subscribe[A](
+      projectId: String,
+      subscription: String,
+      config: PubSubSubscriberConfig,
+      decoder: MessageDecoder[A]
+  ): ZManaged[Blocking, PubSubError, ZStream[Any, Throwable, DecodedMessage[A]]] =
+    for {
+      queue <-
+        Queue
+          .bounded[IO[Throwable, RawMessage]](config.maxOutstandingElementCount)
+          .toManaged(_.shutdown)
+
+      runtime <- ZIO.runtime[Any].toManaged_
+      _ <- createSubscriber(
+        projectId,
+        subscription,
+        config,
+        value =>
+          runtime.unsafeRunAsync_(
+            queue.offer(
+              value
+            )
+          )
+      )
+    } yield ZStream.repeatEffect(takeNextAndDecode(queue, decoder))
+
+  private def createSubscriber(
+      projectId: String,
+      subscription: String,
+      config: PubSubSubscriberConfig,
+      callback: IO[PubSubError, RawMessage] => Unit
+  ): ZManaged[Blocking, PubSubError, GSubscriber] = {
+
+    //uses the default executor provider
+    //default number of threads is number of CPUs and opens only one stream parallel pull count (1)
+    val executorProvider = InstantiatingExecutorProvider
+      .newBuilder()
+      .build()
+
+    val flowControlSettings = FlowControlSettings
+      .newBuilder()
+      .setMaxOutstandingElementCount(config.maxOutstandingElementCount)
+      .setMaxOutstandingRequestBytes(config.maxOutstandingRequestBytes)
+      .build()
+
+    val name = ProjectSubscriptionName.of(projectId, subscription)
+    val subscriber =
+      GSubscriber
+        .newBuilder(name, new PubSubMessageReceiver(callback))
+        .setParallelPullCount(1)
+        .setFlowControlSettings(flowControlSettings)
+        .setExecutorProvider(executorProvider)
+        .setMaxAckExtensionPeriod(Duration.ofMillis(config.maxAckExtensionPeriod.toMillis))
+        .build()
+
+    subscriber.addListener(
+      new Listener {
+        override def failed(
+            state: State,
+            t: Throwable
+        ): Unit = callback(ZIO.fail(PubSubError(t)))
+      },
+      executorProvider.getExecutor()
+    )
+
+    effectBlocking(subscriber.startAsync().awaitRunning())
+      .mapBoth(PubSubError, _ => subscriber)
+      .toManaged(s =>
+        effectBlockingInterrupt(
+          s.stopAsync.awaitTerminated(config.awaitTerminatePeriod.toSeconds, TimeUnit.SECONDS)
+        ).ignore
+      )
+
+  }
+
+  def takeNextAndDecode[A](
+      queue: Queue[IO[Throwable, RawMessage]],
+      decoder: MessageDecoder[A]
+  ): ZIO[Any, Throwable, DecodedMessage[A]] =
+    for {
+      message <- queue.take
+      value: RawMessage <- message
+    } yield DecodedMessage(decoder.decode(value.value), value.ack, value.nack)
+
+  class PubSubMessageReceiver(
+      callback: IO[PubSubError, RawMessage] => Unit
+  ) extends MessageReceiver {
+
+    override def receiveMessage(message: PubsubMessage, consumer: AckReplyConsumer): Unit =
+      callback(
+        ZIO.succeed(RawMessage(message, IO.effect(consumer.ack()), IO.effect(consumer.nack())))
+      )
+
+  }
+
+}

--- a/src/main/scala/subscriber/PubSubSubscriberConfig.scala
+++ b/src/main/scala/subscriber/PubSubSubscriberConfig.scala
@@ -1,0 +1,10 @@
+package subscriber
+
+import scala.concurrent.duration._
+
+case class PubSubSubscriberConfig(
+    maxOutstandingElementCount: Int = 10000,
+    maxOutstandingRequestBytes: Int = 100 * 1024 * 1024, //100MB
+    maxAckExtensionPeriod: FiniteDuration = 10.seconds,
+    awaitTerminatePeriod: FiniteDuration = 5.seconds
+)

--- a/src/main/scala/subscriber/package.scala
+++ b/src/main/scala/subscriber/package.scala
@@ -1,0 +1,21 @@
+import com.google.pubsub.v1.PubsubMessage
+import zio.{ IO, Task }
+
+package object subscriber {
+
+  final case class RawMessage(
+      value: PubsubMessage,
+      ack: Task[Unit],
+      nack: Task[Unit]
+  )
+
+  final case class DecodedMessage[A](
+      value: IO[DecodingFailure, A],
+      ack: Task[Unit],
+      nack: Task[Unit]
+  )
+
+  final case class DecodingFailure(cause: Throwable) extends Throwable("Decoding subscription message failed", cause)
+  final case class PubSubError(cause: Throwable) extends Throwable("PubSub subscription failed", cause)
+
+}

--- a/src/main/scala/subscriber/package.scala
+++ b/src/main/scala/subscriber/package.scala
@@ -1,13 +1,7 @@
-import com.google.pubsub.v1.PubsubMessage
 import zio.{ IO, Task }
 
 package object subscriber {
-
-  final case class RawMessage(
-      value: PubsubMessage,
-      ack: Task[Unit],
-      nack: Task[Unit]
-  )
+  abstract class SubscriptionError(msg: String, cause: Throwable) extends Throwable(msg, cause)
 
   final case class DecodedMessage[A](
       value: IO[DecodingFailure, A],
@@ -15,7 +9,7 @@ package object subscriber {
       nack: Task[Unit]
   )
 
-  final case class DecodingFailure(cause: Throwable) extends Throwable("Decoding subscription message failed", cause)
-  final case class PubSubError(cause: Throwable) extends Throwable("PubSub subscription failed", cause)
+  final case class DecodingFailure(cause: Throwable) extends SubscriptionError("Decoding message failed", cause)
+  final case class PubSubError(cause: Throwable) extends SubscriptionError("PubSub subscription failed", cause)
 
 }


### PR DESCRIPTION
The goal here is to provide an interface to consume pubsub subscriptions as a ZStream, allowing for manual acknowledgment os the message.

It uses ZStream.effectAsyncManaged to build a stream from the managed resource